### PR TITLE
App-8: [Fix] Filled Bill form not reset upon changing friend

### DIFF
--- a/08-Eat-n-split/src/App.js
+++ b/08-Eat-n-split/src/App.js
@@ -77,6 +77,7 @@ export default function App() {
 
       {selectedFriend && (
         <FormSplitBill
+          key={selectedFriend.id}
           selectedFriend={selectedFriend}
           onSubmitBill={handleSplitBill}
         />


### PR DESCRIPTION

As you can see in the video, the filled bill form can now be reset by selecting other friends and
that is done by providing a changing key for the component responsible for handling the split bill form.

[Screencast from 14-10-23 01:13:31 PM IST.webm](https://github.com/Akash-ninja/React-mini-apps/assets/61377176/de7dbc13-b736-48a8-99f0-3005a5585aaa)
